### PR TITLE
Add watchOS and tvOS targets

### DIFF
--- a/crashkios/build.gradle
+++ b/crashkios/build.gradle
@@ -9,6 +9,11 @@ kotlin {
     iosArm32()
     iosArm64()
     iosX64("ios")
+    watchosArm32()
+    watchosArm64()
+    watchosX86()
+    tvosArm64()
+    tvosX64()
 
     sourceSets {
         commonMain {
@@ -38,7 +43,12 @@ kotlin {
         configure([/*targets.iosX64,*/
                    targets.macosX64,
                    targets.iosArm32,
-                   targets.iosArm64
+                   targets.iosArm64,
+                   targets.watchosArm32,
+                   targets.watchosArm64,
+                   targets.watchosX86,
+                   targets.tvosArm64,
+                   targets.tvosX64
         ]) {
             compilations.main.source(sourceSets.iosMain)
             compilations.test.source(sourceSets.iosTest)


### PR DESCRIPTION
Since Firebase 6.33.0 you can use Crashlytics on watchOS to upload non-fatal crashes. I would like to use CrashKiOS on watchOS so this PR adds the required targets.

Firebase Crashlytics also supports tvOS, so I added tvOS targets as well.