### PR TITLE
Update README with new library version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ kotlin {
     sourceSets {
         iosMain {
             dependencies {
-                api "co.touchlab:crashkios:0.2.1"
+                api "co.touchlab:crashkios:0.3.0"
             }
         } 
     }


### PR DESCRIPTION
I just tried to use this library and Android Studio warned me about the kotlin compatibility. Version 0.3.0 solves this, so it is interesting to reflect that in the README file.